### PR TITLE
Enable use of TypeScript

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/client/package.json
+++ b/client/package.json
@@ -5,17 +5,21 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
+    "@digital-taco/eslint-config": "^1.1.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
+    "@tsconfig/svelte": "^2.0.1",
     "eslint-plugin-svelte3": "^3.2.1",
     "prettier": "^2.4.1",
     "prettier-plugin-svelte": "^2.4.0",
     "svelte": "^3.37.0",
+    "svelte-check": "^2.2.7",
+    "svelte-preprocess": "^4.9.8",
+    "tslib": "^2.3.1",
+    "typescript": "^4.4.3",
     "vite": "^2.6.4"
-  },
-  "dependencies": {
-    "@digital-taco/eslint-config": "^1.1.1"
   }
 }

--- a/client/src/lib/ImageContainer.svelte
+++ b/client/src/lib/ImageContainer.svelte
@@ -1,6 +1,6 @@
-<script>
-  export let image;
-  export const handleImageClick = (e) => {
+<script lang="ts">
+  export let image: string;
+  export const handleImageClick = () => {
     console.log('Image clicked - eventually this will do something COOL');
   };
 </script>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,7 +1,0 @@
-import App from './App.svelte'
-
-const app = new App({
-  target: document.getElementById('app'),
-})
-
-export default app

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,0 +1,7 @@
+import App from "./App.svelte";
+
+const app = new App({
+  target: document.getElementById("app")!,
+});
+
+export default app;

--- a/client/svelte.config.js
+++ b/client/svelte.config.js
@@ -1,0 +1,7 @@
+import sveltePreprocess from "svelte-preprocess";
+
+export default {
+  // Consult https://github.com/sveltejs/svelte-preprocess
+  // for more information about preprocessors
+  preprocess: sveltePreprocess(),
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+
+  "include": ["src/**/*", "src/node_modules"],
+  "exclude": ["node_modules/*", "__sapper__/*", "public/*"],
+
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "module": "esnext",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true
+  }
+}


### PR DESCRIPTION
Use TypeScript in a .svelte component with
`<script lang="ts">`

You can also create `.ts` files wherever you would have created a `.js` file.

JavaScript is still acceptable -- just use `<script>` and `.js`.